### PR TITLE
Multiple resource handlers

### DIFF
--- a/avcDaemon/avData.c
+++ b/avcDaemon/avData.c
@@ -2475,7 +2475,7 @@ le_avdata_ResourceEventHandlerRef_t le_avdata_AddResourceEventHandler
             LE_INFO("Registering handler on %s", key);
             assetDataPtr = le_hashmap_GetValue(iter);
             if(assetDataPtr->nHandlers >= MAX_ASSET_DATA_HANDLERS) {
-                return LE_NO_MEMORY;
+                return NULL;
             }
             assetDataPtr->handlerPtr[assetDataPtr->nHandlers++] = handlerPtr;
             assetDataPtr->contextPtr = contextPtr;

--- a/avcDaemon/avData.c
+++ b/avcDaemon/avData.c
@@ -75,8 +75,6 @@
 //--------------------------------------------------------------------------------------------------
 #define DOT_DELIMITER_CHAR '.'
 
-#define MAX_ASSET_DATA_HANDLERS 4
-
 //--------------------------------------------------------------------------------------------------
 /**
  *  SLASH as the path delimiter char
@@ -84,6 +82,12 @@
 //--------------------------------------------------------------------------------------------------
 #define SLASH_DELIMITER_CHAR '/'
 
+//--------------------------------------------------------------------------------------------------
+/**
+ *  Space allocated for resource handler callback functions
+ */
+//--------------------------------------------------------------------------------------------------
+#define MAX_ASSET_DATA_HANDLERS 4
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -2462,6 +2466,9 @@ le_avdata_ResourceEventHandlerRef_t le_avdata_AddResourceEventHandler
         {
             LE_INFO("Registering handler on %s", key);
             assetDataPtr = le_hashmap_GetValue(iter);
+            if(assetDataPtr->nHandlers >= MAX_ASSET_DATA_HANDLERS) {
+                return LE_NO_MEMORY;
+            }
             assetDataPtr->handlerPtr[assetDataPtr->nHandlers++] = handlerPtr;
             assetDataPtr->contextPtr = contextPtr;
 

--- a/avcDaemon/avData.c
+++ b/avcDaemon/avData.c
@@ -923,7 +923,7 @@ static void RunEachHandler
     le_avdata_ArgumentListRef_t argListRef =
                                         le_ref_CreateRef(ArgListRefMap, &it->arguments);
     for(int i = 0; i < it->nHandlers; i++) {
-        LE_INFO("Calling handler %d of %d for %s", i, it->nHandlers, path);
+        LE_INFO("Calling handler %d of %d for %s", i + 1, it->nHandlers, path);
         it->handlerPtr[i](path, accessType, argListRef, it->contextPtr);
     }
     if(shouldDelete) {

--- a/avcDaemon/avData.c
+++ b/avcDaemon/avData.c
@@ -931,6 +931,14 @@ static void RunEachHandler
     }
 }
 
+static bool HasHandler
+(
+    AssetData_t* it
+)
+{
+    return it->nHandlers > 0;
+}
+
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -984,7 +992,7 @@ static le_result_t GetVal
     }
 
     // Call registered handler.
-    if ((!isClient) && (assetDataPtr->handlerPtr[0] != NULL))
+    if (!isClient && HasHandler(assetDataPtr))
     {
         RunEachHandler(namespacedPath, LE_AVDATA_ACCESS_READ, assetDataPtr, true);
     }
@@ -2330,7 +2338,7 @@ static void ProcessAvServerExecRequest
         }
         else
         {
-            if (assetDataPtr->handlerPtr[0] == NULL)
+            if (HasHandler(assetDataPtr))
             {
                 LE_ERROR("Server attempts to execute a command, but no command defined.");
                 RespondToAvServer(COAP_NOT_FOUND, NULL, 0);


### PR DESCRIPTION
I noticed (in the code and in practice) that `AssetData_t` only stores one handler function, so I tried to extend it to support up to 4 handler functions.

Note that handler function pointers are never cleared. The index is simply reset and invoking `le_avdata_AddResourceEventHandler` again will overwrite.